### PR TITLE
Evolution params

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ Notes sur les problèmes potentiels:
 III- Utilisation
 ++++++++++++++++++++++++++++++++++++++
 
-Pour créer sa propre interface utilisateur, il suffit d'écrire un fichier de description d'interface en json et d'écrire les scripts de relecture du fichier 'parameters.json' résultant afin d'en déduire les commandes à lancer une fois le formulaire rempli par l'utilisateur. Ces scripts peuvent être écrits dans tout langage exécutable via une commande système (DOS bat, bash shell, python etc...). Dans le cas d'une interface multiOS, il faut cependant faire attention à ce que les commandes soient correctement interprétables sur les différents OS ciblés. Voir les exemples ci-dessous. 
+Pour créer sa propre interface utilisateur, il suffit d'écrire un fichier de description d'interface en json et d'écrire les commandes de post-traitement à lancer  une fois le formulaire rempli par l'utilisateur.
+
+Toute commande exécutable via une commande système (DOS bat, bash shell, scripts python etc...) est valide. Dans le cas d'une interface multiOS, il faut cependant faire attention à ce que les commandes soient correctement interprétables sur les différents OS ciblés. Voir les exemples ci-dessous. 
     
 Le fichier interface en json décrit :
 - l'ensemble des champs à remplir par l'utilisateur
@@ -178,4 +180,6 @@ Il comporte 2 entrées:
    - 'directory' (required): le dossier dans lequel on écrit le fichier 'parameters.json'`;
     - 'resources': un vecteur de path correspondant à des dossiers et fichiers devant exister sur le disque au moment de l'exécution. Il est possible d'utiliser les variables d'environnement pour valider l'existence de ces ressources, en embrassant les variables d'environnement par le caractère '$'.
    
-   'commands' contient un vecteur d'objets 'execute' qui sont les commandes à exécuter. Toute commande exécutable dans un terminal peut être utilisée. Les variables d'environnement sont également interprétées dans la commande en les embrassant par le caractère '$'.
+   'commands' contient un vecteur d'objets 'execute' qui sont les commandes à exécuter. Toute commande exécutable dans un terminal peut être utilisée. 
+   Les paramètres de l'interface peuvent être interprétées dans la commande en embrassant la clef du paramètre par le caractère '$'.
+   Les variables d'environnement sont également interprétées dans la commande de la même manière en les embrassant par le caractère '$'.

--- a/README.md
+++ b/README.md
@@ -151,7 +151,6 @@ Le champ 'ToolTip', optionnel, permet de générer une info-bulle qui s'affiche 
   {
      "Master":"kKeyMaster",
      "Slave":"kKeySlave",
-     "Type":"Dependency",
      "Inverse":false
   }
 

--- a/examples/basic/ihm_basic.json
+++ b/examples/basic/ihm_basic.json
@@ -140,19 +140,16 @@
          {
             "Master":"kSomeCheckBox1",
             "Slave":"kSomeFileSelector",
-            "Type":"Dependency",
             "Inverse":false
          },
          {
             "Master":"kSomeCheckBox2",
             "Slave":"kSomeLineEdit",
-            "Type":"Dependency",
             "Inverse":false
          },
          {
             "Master":"kSomeCheckBox2",
             "Slave":"kSomeRadioButtonGroup",
-            "Type":"Dependency",
             "Inverse":false
          }
       ],

--- a/examples/micmacmgr/ihm_micmacmgr.json
+++ b/examples/micmacmgr/ihm_micmacmgr.json
@@ -733,87 +733,70 @@
         "dependencies":[        {
             "Master":"kEmpriseImage",
             "Slave":"kEmpriseBBoxGroup",
-            "Type":"Dependency",
             "Inverse":true
         },        {
             "Master":"kEmpriseBBox",
             "Slave":"kEmpriseBBoxGroup",
-            "Type":"Dependency",
             "Inverse":false
         },        {
             "Master":"kEmpriseZone",
             "Slave":"kEmpriseBBoxGroup",
-            "Type":"Dependency",
             "Inverse":true
         },        {
             "Master":"kEmpriseImage",
             "Slave":"kEmpriseSHP",
-            "Type":"Dependency",
             "Inverse":true
         },        {
             "Master":"kEmpriseBBox",
             "Slave":"kEmpriseSHP",
-            "Type":"Dependency",
             "Inverse":true
         },        {
             "Master":"kEmpriseZone",
             "Slave":"kEmpriseSHP",
-            "Type":"Dependency",
             "Inverse":false
         },        {
             "Master":"kNoDataNeutral",
             "Slave":"kNoDataValue",
-            "Type":"Dependency",
             "Inverse":false
         },        {
             "Master":"kNoDataKeepZ",
             "Slave":"kNoDataValue",
-            "Type":"Dependency",
             "Inverse":true
         },        {
             "Master":"kNoDataDTM",
             "Slave":"kNoDataValue",
-            "Type":"Dependency",
             "Inverse":true
         },        {
             "Master":"kUseMalt",
             "Slave":"kParamMalt",
-            "Type":"Dependency",
             "Inverse":false
         },        {
             "Master":"kUseMalt",
             "Slave":"kModeTemplateMicMac",
-            "Type":"Dependency",
             "Inverse":true
         },        {
             "Master":"kUseMalt",
             "Slave":"kModeImage",
-            "Type":"Dependency",
             "Inverse":false
         },         {
             "Master":"kUseMalt",
             "Slave":"kParamMalt",
-            "Type":"Dependency",
             "Inverse":false
         },        {
             "Master":"kUseMalt",
             "Slave":"kSousEch",
-            "Type":"Dependency",
             "Inverse":false
         },        {
             "Master":"kModeTemplateMicMac",
             "Slave":"kSousEch",
-            "Type":"Dependency",
             "Inverse":true
         },        {
             "Master":"kModeTerrain",
             "Slave":"kUseMalt",
-            "Type":"Dependency",
             "Inverse":false
         },        {
             "Master":"kModeImage",
             "Slave":"kUseMalt",
-            "Type":"Dependency",
             "Inverse":false
         }],
         "oncreate":{

--- a/examples/minimal/ihm_minimal.json
+++ b/examples/minimal/ihm_minimal.json
@@ -21,15 +21,13 @@
         "oncreate":{
             "prerequisite":{
                 "environment":[
-                    "SOME_REQUIRED_ENVIRONMENT_VARIABLE",
-                    "OPEN_METHOD"
-
+                    "SOME_DIRECTORY"
                 ],
-                "directory":"SOME_REQUIRED_ENVIRONMENT_VARIABLE"
+                "directory":"SOME_DIRECTORY"
             },
             "commands":[
                 {
-                    "execute":"$OPEN_METHOD$  $SOME_REQUIRED_ENVIRONMENT_VARIABLE$/parameters.json"
+                    "execute":"echo  l utilisateur a rentre la valeur $kSomeSimpleLineEdit$ dans le champ kSomeSimpleLineEdit. Le fichier de parametres est ecrit dans le dossier $SOME_DIRECTORY$"
                 }
             ]
         }

--- a/examples/minimal/launch.bat
+++ b/examples/minimal/launch.bat
@@ -14,8 +14,7 @@ echo ROOT=%ROOT%
 cd %SCRIPTPATH%
 
 REM defining requirements
-set SOME_REQUIRED_ENVIRONMENT_VARIABLE=%SCRIPTPATH%
-set OPEN_METHOD=start
+set SOME_DIRECTORY=%SCRIPTPATH%
 
 REM launching electron
 cd %SCRIPTPATH%

--- a/examples/minimal/launch.sh
+++ b/examples/minimal/launch.sh
@@ -9,9 +9,8 @@ cd ..
 ROOT=`pwd`
 
 #defining requirements
-export SOME_REQUIRED_ENVIRONMENT_VARIABLE=$SCRIPTPATH
+export SOME_DIRECTORY=$SCRIPTPATH
 export IHMFILE=$SCRIPTPATH/ihm_minimal.json
-export OPEN_METHOD=open
 
 if [ ! -e $IHMFILE ]; then
     echo current directory must be where the ihm/json file is located

--- a/main.js
+++ b/main.js
@@ -17,8 +17,8 @@ let ihmData = {};
 function createWindow() {
   // Create the browser window.
   mainWindow = new BrowserWindow({
-    width: 800,
-    height: 600,
+    width: 1400,
+    height: 1200,
     webPreferences: {
       nodeIntegration: true,
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-gui-for-command-line-tools",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "description": "Electron GUI for command line tools, app developed by the French National Mapping Agency (IGNF / Institut Geographique National) for its specific use. This app builds a simple GUI from a json description file in order to allow a user to fill a form of parameters in order to launch a set of parameterized command lines.",
   "main": "index.js",
   "scripts": {
@@ -21,7 +21,7 @@
   "license": "CC0-1.0",
   "devDependencies": {
     "ejs-electron": "^2.0.3",
-    "ejs-ign": "^2.1.7",
+    "ejs-ign": "^2.2.0",
     "electron": "^8.5.5",
     "electron-react-devtools": "^0.5.3",
     "eslint": "^7.22.0",


### PR DESCRIPTION
* Type:Dependency rendu obsolète 
* possibilité d'utiliser directement les paramètres de l'interface dans les commandes 'execute' sans passer par le fichier 'parameters.json'